### PR TITLE
fix an issue where properties that have been removed from the session…

### DIFF
--- a/lib/express-session-rethinkdb.js
+++ b/lib/express-session-rethinkdb.js
@@ -47,7 +47,7 @@ module.exports = function (session) {
       expires: new Date().getTime() + (sess.cookie.originalMaxAge || this.sessionTimeout),
       session: JSON.stringify(sess)
     };
-    r.table(this.table).insert(sessionToStore, { conflict: 'update' }).run().then(function (data) {
+    r.table(this.table).insert(sessionToStore, { conflict: 'replace' }).run().then(function (data) {
       fn();
     }).error( function (err) {
       fn(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-session-rethinkdb",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "RethinkDB session store for Express 4.x",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
… are not removed in the DB

Due to the use of conflict: 'update' in the set method properties that have been removed from the session object won't be removed from the database. Setting this to conflict: 'replace' will resolve the issue and is safe due to the nature of express-session which pushes the new session object in it's entirety to the Store to be processed.
