### PR TITLE
Silence rethinkdbdash example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var rdbStore = new RDBStore({
     max: 1000,
     timeout: 20,
     timeoutError: 1000,
-    silent: true
+    silent: false
   },
   table: 'session',
   sessionTimeout: 86400000,

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ var rdbStore = new RDBStore({
     buffer: 50,
     max: 1000,
     timeout: 20,
-    timeoutError: 1000
+    timeoutError: 1000,
+    silent: true
   },
   table: 'session',
   sessionTimeout: 86400000,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var rdbStore = new RDBStore({
     max: 1000,
     timeout: 20,
     timeoutError: 1000,
-    silent: false
+    silent: true
   },
   table: 'session',
   sessionTimeout: 86400000,


### PR DESCRIPTION
I recommend that the docs should have an example of how to stop the underlying rethinkdbdash library from logging connection data.

The default is fairly unintuitive, IMHO.
