### PR TITLE
Fixed store race condition that happend with passportjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,11 @@ module.exports = function (session) {
   RethinkStore.prototype.get = function (sid, fn) {
     var sdata = cache.get('sess-'+sid);
     if (sdata) {
-      if( this.debug ){ console.log( 'SESSION: (get)', JSON.parse(sdata.session) ) };
+      if( this.debug ){ console.log( 'SESSION: (cache get)', JSON.parse(sdata.session) ) };
       return fn(null, JSON.parse(sdata.session));
     } else {
         r.table(this.table).get(sid).run().then(function (data) {
+          if( this.debug ){ console.log( 'SESSION: (get)', JSON.parse(data.session) ) };
           return fn(null, data ? JSON.parse(data.session) : null);
         }).error(function (err) {
           return fn(err);
@@ -53,19 +54,21 @@ module.exports = function (session) {
 
   // Set Session
   RethinkStore.prototype.set = function (sid, sess, fn) {
+    var debug = this.debug;
     var sessionToStore = {
       id: sid,
       expires: new Date().getTime() + (sess.cookie.originalMaxAge || this.sessionTimeout),
       session: JSON.stringify(sess)
     };
-
+    cache.put( 'sess-' + sessionToStore.id, sessionToStore, 30000 );
+    if (this.debug){ console.log( 'SESSION: (set)', sessionToStore ); }
     r.table(this.table).insert(sessionToStore, { conflict: 'replace', returnChanges: true }).run().then(function (data) {
       var sdata = null;
       if(data.changes[0] != null)
         sdata = data.changes[0].new_val || null;
 
+      if (debug){ console.log( 'SESSION: (setted)', sdata.id ); }
       if (sdata){
-          if (this.debug){ console.log( 'SESSION: (set)', sdata.id ); }
           cache.put( 'sess-'+ sdata.id, sdata, 30000 );
       }
       if (typeof fn === 'function') {
@@ -74,6 +77,8 @@ module.exports = function (session) {
       else
         return null
     }).error(function (err) {
+      if (debug){ console.log( 'SESSION: (errored)', err ); }
+      cache.del('sess-' + sessionToStore.id);
       return fn(err);
     });
   };


### PR DESCRIPTION
These changes will fix the race condition that occurs after setting/updating the session data and redirecting the page which caused the store to reload the old session from cache and update the session in store causing the new session data to be deleted.

Bug flow:
1. A new session is created when user opens the website for the first time
2. The session will be updated for each visited page
3. When the user loges in passport will attach the user property to the session data and update the store
4. After the user is logged in he will be redirected to a new page, in this case the store will be waiting "save callback" to be fired to update the cache. mean while the redirect will do the following:
    1. Get the current session which will be fetched from the cached data (old data because it happened at the same time or before firing the save callback)
    2. The session will be updated for the new page visit with the fetched data (the old data without the passportjs user property)
    3. session will be overridden and the user will be considered as logged out

Solution:
I've placed the cache.put in the set method to be outside the save callback, the cache will also be updated once the save callback fires or it will be deleted in case of error.




 
